### PR TITLE
cleanup unused pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,5 @@ docs = ["sphinx"]
 Homepage = "https://github.com/csett86/graphite-render"
 Repository = "https://github.com/csett86/graphite-render"
 
-[tool.setuptools]
-zip-safe = false
-include-package-data = true
-
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]


### PR DESCRIPTION
zip_safe was only relevant for egg formats, no longer required
include-package-data = true is the default since setuptools 61
